### PR TITLE
Flip angle when positron direction flipped in RECO

### DIFF
--- a/acceptance/include/PIAccAnalyzer.hpp
+++ b/acceptance/include/PIAccAnalyzer.hpp
@@ -29,13 +29,14 @@ namespace PIAna
     void DoAction(PIEventData&) override;
     void End() override;
 
-    // void e_topo_name(const std::string &n) { e_topo_name_ = n; }
     void pivertex_name(const std::string &n) { pivertex_name_ = n; }
     void estart_name(const std::string &n) { estart_name_ = n; }
+    void ehits_name(const std::string &n) { ehits_name_ = n; }
     void true_pivertex_name(const std::string &n) { true_pivertex_name_ = n; }
     void true_estart_name(const std::string &n) { true_estart_name_ = n; }
     void topoflag_name(const std::string &n) { topoflag_name_ = n; }
     void edirection_name(const std::string &n) { edirection_name_ = n; }
+    void etruemom_name(const std::string &n) { etruemom_name_ = n; }
 
   protected:
     void analyze(const PIEventData&) override;
@@ -51,11 +52,16 @@ namespace PIAna
     std::string true_estart_name_;
     std::string topoflag_name_;
     std::string edirection_name_;
+    std::string ehits_name_;
+    std::string etruemom_name_;
 
     TTree* t_;
     TH2D *h_pistop_rec_xy_;
     TH2D *h_pistop_rec_xy_5hits_;
     TH2D *h_e_rec_angle_;
+    TH2D *h_e_truemom_angle_;
+    TH2D *h_e_angle_diff_;
+    TH2D *h_e_angle_diff_p_;
     Float_t pi_x_;
     Float_t pi_y_;
     Float_t pi_z_;
@@ -70,6 +76,13 @@ namespace PIAna
     Float_t e_rec_z_;
     Float_t e_rec_theta_;
     Float_t e_rec_phi_;
+    Float_t e_px_;
+    Float_t e_py_;
+    Float_t e_pz_;
+    UChar_t e_rec_nhits_;
+    Float_t e_rec_xs_[5];
+    Float_t e_rec_ys_[5];
+    Float_t e_rec_zs_[5];
   };
 };
 #endif

--- a/acceptance/include/PIAnaAcc_linkdef.h
+++ b/acceptance/include/PIAnaAcc_linkdef.h
@@ -43,6 +43,7 @@
 #pragma link C++ class PIAna::PIHitProducer+;
 #pragma link C++ class PIAna::PIEventAnalyzer+;
 #pragma link C++ class PIAna::PITrueDecPos+;
+#pragma link C++ class PIAna::PITrueMomProducer+;
 #pragma link C++ class PIAna::XYZPointWrapper+;
 /* #pragma link C++ class PIAna::PointWrapper<ROOT::Math::XYZPoint>+; */
 #pragma link C++ class PIAna::PIAccAnalyzer+;

--- a/acceptance/include/PITopoProducer.hpp
+++ b/acceptance/include/PITopoProducer.hpp
@@ -30,7 +30,9 @@ namespace PIAna
 
     std::pair<bool, ROOT::Math::Polar3DVector>
     positron_direction(const std::vector<const PIAnaHit *> hits,
-                       const PIAnaPointCloud::Point pivertex, ROOT::Math::XYZPoint&);
+                       const PIAnaPointCloud::Point pivertex,
+                       ROOT::Math::XYZPoint &,
+                       std::vector<ROOT::Math::XYZPoint> &);
 
 
     /**

--- a/acceptance/include/PITrueMomProducer.hpp
+++ b/acceptance/include/PITrueMomProducer.hpp
@@ -1,0 +1,44 @@
+/*********************************************************************
+*                                                                    *
+* 2024-04-30 15:08:28                                                *
+* acceptance/include/PITrueMomProducer.hpp                           *
+*                                                                    *
+*********************************************************************/
+
+#ifndef __PI_TrueMomProducer__
+#define __PI_TrueMomProducer__
+
+#include "PIEventProducer.hpp"
+
+namespace PIAna
+{
+  class PITrueMomProducer : public PIEventProducer
+  {
+  public:
+    enum class PiDecayMode { undefined, pienu, pimue };
+    PITrueMomProducer(const std::string&);
+    ~PITrueMomProducer();
+
+    void Begin() override;
+    void DoAction(PIEventData&) override;
+    void End() override;
+
+    void decay_mode(PiDecayMode mode) { pi_mode_ = mode; }
+
+  protected:
+    void produce(PIEventData&) override;
+    void fill_dummy(PIEventData&) override;
+    void report() override;
+
+  private:
+    const int pip_pdgid_; // pi+
+    const int pim_pdgid_; // pi-
+    const int mup_pdgid_; // mu+
+    const int mum_pdgid_; // mu-
+    const int ep_pdgid_;  // e+
+    const int em_pdgid_;  // e-
+    const int gamma_pdgid_; // gamm
+    PiDecayMode pi_mode_;
+  };
+};
+#endif

--- a/acceptance/src/PIAccAnalyzer.cpp
+++ b/acceptance/src/PIAccAnalyzer.cpp
@@ -5,12 +5,14 @@
 *                                                                    *
 *********************************************************************/
 
+#include "PIMCInfo.hh"
 #include "TError.h"
 #include "TFile.h"
 #include "TTree.h"
 #include "TH2D.h"
 #include "Math/Vector3D.h"
 #include "Math/Point3D.h"
+#include "Math/GenVector/VectorUtil.h"
 #include "TMath.h"
 
 #include "PIJobManager.hpp"
@@ -21,7 +23,9 @@
 
 PIAna::PIAccAnalyzer::PIAccAnalyzer(const std::string &name)
     : PIEventAnalyzer(name), t_(0), h_pistop_rec_xy_(0),
-      h_pistop_rec_xy_5hits_(0), h_e_rec_angle_(0)
+      h_pistop_rec_xy_5hits_(0), h_e_rec_angle_(0),
+      h_e_angle_diff_(0),
+      h_e_angle_diff_p_(0)
 {
   // fill out what is necessary
 }
@@ -60,6 +64,10 @@ void PIAna::PIAccAnalyzer::Begin()
   t_->Branch("e_rec_z", &e_rec_z_);
   t_->Branch("e_rec_theta", &e_rec_theta_);
   t_->Branch("e_rec_phi", &e_rec_phi_);
+  t_->Branch("e_rec_nhits", &e_rec_nhits_, "e_rec_nhits/b");
+  t_->Branch("e_rec_xs", e_rec_xs_, "e_rec_xs[e_rec_nhits]/F");
+  t_->Branch("e_rec_ys", e_rec_ys_, "e_rec_ys[e_rec_nhits]/F");
+  t_->Branch("e_rec_zs", e_rec_zs_, "e_rec_zs[e_rec_nhits]/F");
   t_->SetDirectory(PIEventAnalyzer::outputfile_);
 
   h_pistop_rec_xy_ = new TH2D(
@@ -69,14 +77,34 @@ void PIAna::PIAccAnalyzer::Begin()
   h_pistop_rec_xy_5hits_ =
       new TH2D("h_pistop_rec_xy_5hits",
                "#pi^{+} stop position in reco level && 5 e hits;x (mm); y (mm);",
-               100, -1, 1, 100, -1, 1);
+               100, -10, 10, 100, -10, 10);
   h_pistop_rec_xy_5hits_->SetDirectory(PIEventAnalyzer::outputfile_);
 
   h_e_rec_angle_ =
       new TH2D("h_e_rec_angle",
-               "e^{+} outgoing directions;#phi_{e} (#pi rad.);cos(#theta_{e});",
+               "e^{+} outgoing directions in reco;#phi_{e} (#pi rad.);cos(#theta_{e});",
                50, -1, 1, 50, -1, 1);
-  h_pistop_rec_xy_->SetDirectory(PIEventAnalyzer::outputfile_);
+  h_e_rec_angle_->SetDirectory(PIEventAnalyzer::outputfile_);
+
+  h_e_truemom_angle_ =
+      new TH2D("h_e_truemom_angle",
+               "True #vec{P}_{e^{+}} direction;#phi_{e} (#pi rad.);cos(#theta_{e});",
+               50, -1, 1, 50, -1, 1);
+  h_e_truemom_angle_->SetDirectory(PIEventAnalyzer::outputfile_);
+
+  h_e_angle_diff_ =
+      new TH2D("h_e_angle_diff",
+               "Residuals of e^{+} direction in solid angles;#phi_{rec} - "
+               "#phi_{mom} (#pi rad);cos(#theta_{rec}) - cos(#theta_{mom});",
+               50, -1, 1, 50, -2, 2);
+  h_e_angle_diff_->SetDirectory(PIEventAnalyzer::outputfile_);
+
+  h_e_angle_diff_p_ = new TH2D(
+      "h_e_angle_diff_p",
+      "Residuals of e^{+} direction in solid angles (dx or dy > 0.2 *2 mm);"
+      "#phi_{rec} - #phi_{mom} (#pi rad);cos(#theta_{rec}) - cos(#theta_{mom});",
+      50, -1, 1, 50, -2, 2);
+  h_e_angle_diff_p_->SetDirectory(PIEventAnalyzer::outputfile_);
 
   // give a summary of parameters at the end.
   if (PIEventAction::verbose_) {
@@ -103,15 +131,19 @@ void PIAna::PIAccAnalyzer::analyze(const PIEventData& event)
   // this method is called in PIEventAnalyzer::DoAction().
   // fill out what is necessary here.
   clear();
+  const auto &eventinfo = event.Get<const PIMCInfo*>("info");
   const auto &flag = event.Get<bool>(topoflag_name_);
 
   const auto &pivertex = event.Get<const ROOT::Math::XYZPoint>(pivertex_name_);
   const auto &true_pivertex =
       event.Get<const XYZPointWrapper>(true_pivertex_name_);
   const auto &estart = event.Get<const ROOT::Math::XYZPoint>(estart_name_);
+  const auto &ehits = event.Get<const std::vector<ROOT::Math::XYZPoint > >(ehits_name_);
   const auto &true_estart = event.Get<const XYZPointWrapper>(true_estart_name_);
   const auto &edirection =
       event.Get<const ROOT::Math::Polar3DVector>(edirection_name_);
+  const auto &etruemom = event.Get<const ROOT::Math::XYZVector>(etruemom_name_);
+
   if (true_pivertex.null() || true_estart.null()) return;
   pi_x_ = true_pivertex.point().X();
   pi_y_ = true_pivertex.point().Y();
@@ -128,6 +160,19 @@ void PIAna::PIAccAnalyzer::analyze(const PIEventData& event)
   e_rec_theta_ = edirection.Theta();
   e_rec_phi_ = edirection.Phi();
 
+  if (!ehits.empty() && ehits.size() != 5) {
+    Fatal("PIAna::PIAnaAnalyzer",
+          ::Form("Number of reconstructed hits from %s is not 5",
+                 ehits_name_.c_str()));
+  }
+  e_rec_nhits_ = ehits.size();
+
+  for (size_t i = 0; i != 5 && !ehits.empty(); ++i) {
+    e_rec_xs_[i] = ehits.at(i).X();
+    e_rec_ys_[i] = ehits.at(i).Y();
+    e_rec_zs_[i] = ehits.at(i).Z();
+  }
+
   // hard code
   const bool not_valid_pi =
       pi_rec_x_ < -1E8 && pi_rec_y_ < -1E8 && pi_rec_z_ < -1E8;
@@ -141,7 +186,33 @@ void PIAna::PIAccAnalyzer::analyze(const PIEventData& event)
     const auto ystrip = PIAnaHit::find_strip(pi_rec_y_);
     if (xstrip.first < 90 && xstrip.first >= 10 && ystrip.first < 90 &&
         ystrip.first >= 10) {
-      h_e_rec_angle_->Fill(e_rec_phi_/TMath::Pi(), TMath::Cos(e_rec_theta_));
+      h_e_rec_angle_->Fill(e_rec_phi_ / TMath::Pi(), TMath::Cos(e_rec_theta_));
+      h_e_truemom_angle_->Fill(etruemom.Phi() / TMath::Pi(),
+                               TMath::Cos(etruemom.Theta()));
+      const double delta_phi = ROOT::Math::VectorUtil::Phi_mpi_pi(e_rec_phi_ - etruemom.Phi());
+      const double delta_costheta = TMath::Cos(e_rec_theta_) -
+          TMath::Cos(etruemom.Theta());
+
+      h_e_angle_diff_->Fill(delta_phi / TMath::Pi(), delta_costheta);
+
+      const double dxordy = 0.21;
+      const double x1 = estart.X();
+      const double y1 = estart.Y();
+      for (const auto &p : ehits) {
+        const double x2 = p.X();
+        const double y2 = p.Y();
+        if (std::abs(x2 - x1) > dxordy || std::abs(y2 - y1) > dxordy) {
+          h_e_angle_diff_p_->Fill(delta_phi / TMath::Pi(), delta_costheta);
+          break;
+        }
+      }
+      if (PIEventAction::verbose_) {
+        if (std::abs(delta_costheta) > 0.5) {
+          Error("PIAna::PIAccAnalyzer",
+                ::Form("Delta cosTheta %f > 0.5 at run:event:eventid = %d:%d:%d", delta_costheta,
+                      eventinfo->GetRun(), eventinfo->GetEvent(), eventinfo->GetEventID()));
+        }
+      }
     }
   }
 }
@@ -168,4 +239,8 @@ void PIAna::PIAccAnalyzer::clear()
     e_rec_z_ = -1E9;
     e_rec_theta_ = -1E9;
     e_rec_phi_ = -1E9;
+    e_rec_nhits_ = 0;
+    std::fill_n(e_rec_xs_, 5, -1E9);
+    std::fill_n(e_rec_ys_, 5, -1E9);
+    std::fill_n(e_rec_zs_, 5, -1E9);
 }

--- a/acceptance/src/PITrueMomProducer.cpp
+++ b/acceptance/src/PITrueMomProducer.cpp
@@ -1,0 +1,112 @@
+/*********************************************************************
+*                                                                    *
+* 2024-04-30 15:08:28                                                *
+* acceptance/src/PITrueMomProducer.cpp                               *
+*                                                                    *
+*********************************************************************/
+
+#include "TError.h"
+#include "TClonesArray.h"
+#include "Math/Vector3D.h"
+
+#include "PIMCDecay.hh"
+
+#include "PIJobManager.hpp"
+#include "PIEventData.hpp"
+#include "PITrueMomProducer.hpp"
+#include <sstream>
+
+PIAna::PITrueMomProducer::PITrueMomProducer(const std::string &name)
+    : PIEventProducer(name), pip_pdgid_(211), pim_pdgid_(-211), mum_pdgid_(13),
+      mup_pdgid_(-13), em_pdgid_(11), ep_pdgid_(-11), gamma_pdgid_(22),
+      pi_mode_(PiDecayMode::undefined)
+{
+  // fill out what is necessary
+}
+
+PIAna::PITrueMomProducer::~PITrueMomProducer()
+{
+  // fill out what is necessary
+}
+
+void PIAna::PITrueMomProducer::Begin()
+{
+  // always call Begin() of base class first to ensure things are initialized.
+  PIEventProducer::Begin();
+  // always check if manager is available.
+  if (!PIEventAction::mgr_) {
+    Fatal("PIAna::PITrueMomProducer", "PIJobManager is not set.");
+  }
+
+  // fill out what is necessary from here.
+  if (pi_mode_ == PiDecayMode::undefined) {
+    Fatal("PIAna::PITrueMomProducer", "decay channel of pions is undefined.");
+  }
+  // give a summary of parameters at the end.
+  if (PIEventAction::verbose_) {
+    report();
+  }
+}
+
+void PIAna::PITrueMomProducer::DoAction(PIEventData& event)
+{
+  // Do not modify this function.
+  PIEventProducer::DoAction(event);
+}
+
+void PIAna::PITrueMomProducer::End()
+{
+  // fill out what is necessary from here.
+
+  // always call End() of base class at the end.
+  PIEventProducer::End();
+}
+
+void PIAna::PITrueMomProducer::produce(PIEventData& event)
+{
+  // this method is called in PIEventProducer::DoAction().
+  // When no product can be made, call customized fill_dummy().
+  // fill out what is necessary.
+
+  ROOT::Math::XYZVector emom;
+
+  const TClonesArray *decays = event.Get<const TClonesArray *>("decay");
+
+  for (Long64_t ipar = 0; ipar != decays->GetEntries(); ++ipar) {
+    auto particle = (PIMCDecay *)decays->At(ipar);
+
+    const bool ispiplus = particle->GetMotherPDGID() == pip_pdgid_
+      && pi_mode_ == PiDecayMode::pienu;
+    const bool ismuplus = particle->GetMotherPDGID() == mup_pdgid_
+      && pi_mode_ == PiDecayMode::pimue;
+    if (ispiplus || ismuplus) {
+      for (int idau = 0; idau < particle->GetNDaughters(); ++idau) {
+        if (particle->GetDaughterPDGIDAt(idau) == ep_pdgid_) {
+          emom = particle->GetDaughterMomAt(idau);
+        }
+      }
+    }
+  }
+
+  if (emom.Mag2() < 1E-9) {
+    Warning("PIAna::PITrueMomProducer", "|P|^2 of positron < 1E-9");
+  } else {
+    if (PIEventAction::verbose_) {
+      Info("PIAna::PITrueMomProducer",
+           ::Form("Positron momentum (%f, %f, %f)", emom.X(), emom.Y(), emom.Z()));
+    }
+  }
+
+  event.Put<ROOT::Math::XYZVector>(
+      ::Form("%s_emom", PIEventProducer::GetName().c_str()), emom);
+}
+
+void PIAna::PITrueMomProducer::fill_dummy(PIEventData& event)
+{
+  // fill dummy values here.
+}
+
+void PIAna::PITrueMomProducer::report()
+{
+  // fill out what is necessary from here.
+}

--- a/acceptance/test/run_pienu.C
+++ b/acceptance/test/run_pienu.C
@@ -1,0 +1,66 @@
+#include <Rtypes.h>
+#ifdef __CLING__
+R__LOAD_LIBRARY(../../../PIAnalysis_install/lib/libPiAnaAcc.so)
+R__LOAD_LIBRARY(../../../PIAnalysis_install/lib/libPiRootDict.so)
+#else
+#include "PITrueDecPos.hpp"
+#include "PIEvtNbFilter.hpp"
+#include "PIAnaConst.hpp"
+#include "PIFilterPiDAR.hpp"
+#include "PIHitProducer.hpp"
+#include "PITopoProducer.hpp"
+#include "PITrueMomProducer.hpp"
+#include "PIJobManager.hpp"
+#include "PITreeAnalyzer.hpp"
+#include "PIAccAnalyzer.hpp"
+#endif
+
+void run_pienu()
+{
+
+    gErrorIgnoreLevel = kError;
+
+  PIAna::PIJobManager pi;
+  pi.treename("sim");
+
+  std::string filename;
+  ifstream filelists("pienu_files.txt");
+  while (std::getline(filelists, filename)) {
+
+      if (filename[0] != '#') {
+
+      pi.add_file(filename);
+      std::cout << "Added "<< filename << "\n";
+      }
+  }
+
+  //pi.out_file("pienu_output_20240430.root");
+  pi.out_file("pienu-output-test.root");
+  pi.add_action("PiDAR",
+                std::make_unique<PIAna::PIPiDARFilter>("PiDAR", static_cast<int>(PIAna::EvtCode::PiDAR)));
+  pi.add_action("DecPos", std::make_unique<PIAna::PITrueDecPos>("DecPos"));
+  auto decpos = dynamic_cast<PIAna::PITrueDecPos *>(pi.get_action("DecPos"));
+  pi.add_action("TrueEMom", std::make_unique<PIAna::PITrueMomProducer>("TrueEMom"));
+  auto emom = dynamic_cast<PIAna::PITrueMomProducer *>(pi.get_action("TrueEMom"));
+  emom->decay_mode(PIAna::PITrueMomProducer::PiDecayMode::pienu);
+  pi.add_action("RecHits", std::make_unique<PIAna::PIHitProducer>("RecHits"));
+  auto rechits = dynamic_cast<PIAna::PIHitProducer *>(pi.get_action("RecHits"));
+  rechits->de_thres(0.0155);
+  pi.add_action("Topo", std::make_unique<PIAna::PITopoProducer>("Topo"));
+  auto topoproducer =
+      dynamic_cast<PIAna::PITopoProducer *>(pi.get_action("Topo"));
+  topoproducer->min_tcluster(2);
+  pi.add_action("AccAna", std::make_unique<PIAna::PIAccAnalyzer>("AccAna"));
+  auto accana = dynamic_cast<PIAna::PIAccAnalyzer *>(pi.get_action("AccAna"));
+  accana->topoflag_name("Topo_flag");
+  accana->pivertex_name("Topo_pivertex");
+  accana->estart_name("Topo_estart");
+  accana->ehits_name("Topo_ehits");
+  accana->edirection_name("Topo_edirection");
+  accana->true_pivertex_name("DecPos_pivertex");
+  accana->true_estart_name("DecPos_estart");
+  accana->etruemom_name("TrueEMom_emom");
+  pi.begin();
+  pi.run();
+  pi.end();
+}

--- a/acceptance/test/test_decay_mom.C
+++ b/acceptance/test/test_decay_mom.C
@@ -1,0 +1,57 @@
+#include <Rtypes.h>
+#ifdef __CLING__
+R__LOAD_LIBRARY(../../../PIAnalysis_install/lib/libPiAnaAcc.so)
+R__LOAD_LIBRARY(../../../PIAnalysis_install/lib/libPiRootDict.so)
+#else
+#include "PIEvtNbFilter.hpp"
+#include "PIAnaConst.hpp"
+#include "PIFilterPiDAR.hpp"
+#include "PITrueMomProducer.hpp"
+#include "PIJobManager.hpp"
+#endif
+
+void run_test_pienu()
+{
+  PIAna::PIJobManager pi;
+  pi.treename("sim");
+  pi.add_file("pienu-test.root");
+  pi.out_file("pienu-job-output.root");
+  pi.add_action("PiDAR",
+                std::make_unique<PIAna::PIPiDARFilter>("PiDAR", static_cast<int>(PIAna::EvtCode::PiDAR)));
+  pi.add_action("DecPos", std::make_unique<PIAna::PITrueDecPos>("DecPos"));
+  auto decpos = dynamic_cast<PIAna::PITrueDecPos *>(pi.get_action("DecPos"));
+  // decpos->verbose(true);
+  pi.add_action("TrueEMom", std::make_unique<PIAna::PITrueMomProducer>("TrueMom"));
+  auto emom = dynamic_cast<PIAna::PITrueMomProducer *>(pi.get_action("TrueEMom"));
+  emom->decay_mode(PIAna::PITrueMomProducer::PiDecayMode::pienu);
+  emom->verbose(true);
+  pi.begin();
+  pi.run();
+  pi.end();
+}
+
+void run_test_pimue()
+{
+  PIAna::PIJobManager pi;
+  pi.treename("sim");
+  pi.add_file("pimunu-test.root");
+  pi.out_file("pimue-job-output.root");
+  pi.add_action("PiDAR",
+                std::make_unique<PIAna::PIPiDARFilter>("PiDAR", static_cast<int>(PIAna::EvtCode::PiDAR)));
+  pi.add_action("DecPos", std::make_unique<PIAna::PITrueDecPos>("DecPos"));
+  auto decpos = dynamic_cast<PIAna::PITrueDecPos *>(pi.get_action("DecPos"));
+  // decpos->verbose(true);
+  pi.add_action("TrueEMom", std::make_unique<PIAna::PITrueMomProducer>("TrueMom"));
+  auto emom = dynamic_cast<PIAna::PITrueMomProducer *>(pi.get_action("TrueEMom"));
+  emom->decay_mode(PIAna::PITrueMomProducer::PiDecayMode::pimue);
+  emom->verbose(true);
+  pi.begin();
+  pi.run();
+  pi.end();
+}
+
+void test_decay_mom()
+{
+  run_test_pienu();
+  run_test_pimue();
+}

--- a/acceptance/test/test_pienu.C
+++ b/acceptance/test/test_pienu.C
@@ -1,0 +1,53 @@
+#ifdef __CLING__
+R__LOAD_LIBRARY(libPiAnaAcc.so)
+R__LOAD_LIBRARY(libPiRootDict.so)
+#else
+#include <Rtypes.h>
+#include "PITrueDecPos.hpp"
+#include "PIEvtNbFilter.hpp"
+#include "PIAnaConst.hpp"
+#include "PIFilterPiDAR.hpp"
+#include "PIHitProducer.hpp"
+#include "PITopoProducer.hpp"
+#include "PIJobManager.hpp"
+#include "PITreeAnalyzer.hpp"
+#include "PIAccAnalyzer.hpp"
+#endif
+
+void run_pienu()
+{
+  PIAna::PIJobManager pi;
+  pi.treename("sim");
+  pi.add_file("pienu-test.root");
+  pi.out_file("pienu-job-output.root");
+  pi.add_action("PiDAR",
+                std::make_unique<PIAna::PIPiDARFilter>("PiDAR", static_cast<int>(PIAna::EvtCode::PiDAR)));
+  pi.add_action("DecPos", std::make_unique<PIAna::PITrueDecPos>("DecPos"));
+  auto decpos = dynamic_cast<PIAna::PITrueDecPos *>(pi.get_action("DecPos"));
+  // decpos->verbose(true);
+  pi.add_action("RecHits", std::make_unique<PIAna::PIHitProducer>("RecHits"));
+  auto rechits = dynamic_cast<PIAna::PIHitProducer *>(pi.get_action("RecHits"));
+  // rechits->verbose(true);
+  rechits->de_thres(1);
+  pi.add_action("Topo", std::make_unique<PIAna::PITopoProducer>("Topo"));
+  auto topoproducer =
+      dynamic_cast<PIAna::PITopoProducer *>(pi.get_action("Topo"));
+  topoproducer->min_tcluster(2);
+  // topoproducer->verbose(true);
+  pi.add_action("AccAna", std::make_unique<PIAna::PIAccAnalyzer>("AccAna"));
+  auto accana = dynamic_cast<PIAna::PIAccAnalyzer *>(pi.get_action("AccAna"));
+  accana->topoflag_name("Topo_flag");
+  accana->pivertex_name("Topo_pivertex");
+  accana->estart_name("Topo_estart");
+  accana->edirection_name("Topo_edirection");
+  accana->true_pivertex_name("DecPos_pivertex");
+  accana->true_estart_name("DecPos_estart");
+  pi.begin();
+  pi.run();
+  pi.end();
+}
+
+void test_pienu()
+{
+  run_pienu();
+}


### PR DESCRIPTION
The fit procedure does not have a preference of time flow. The fitted direction can be along t or -t.

Now I put an check, **assuming the correctness of positron starting position**.

As long as the vector pointing from start to end position is opposite to the fitted direction, i.e., dot product is negative, I flip the fitted direction.
- theta -> pi-theta
- phi -> pi + phi and constrain it from -pi and pi

I also added residual check by comparing momentum of positron at production point and fitted direction.

To summarize:
- I stored five hits for positron.
- I saved e+ momentum at production point.